### PR TITLE
Update prettyjson to 1.1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "prettyjson": "~0.13.0"
+    "prettyjson": "^1.1.3"
   },
   "devDependencies": {
     "mocha": "^1.18.2",

--- a/test.js
+++ b/test.js
@@ -12,11 +12,12 @@ describe('format-error#format', function(){
   });
 
   it('finds the stack', function(){
-    assert.include('Error:    something broke', this.message);
+    assert.include('Error: \n  """\n    something broke', this.message);
   });
 
   it('finds inner stacks', function(){
-    assert.include('Error: some inner thing broke', this.message);
+    assert.include('Error: \n    """\n      some inner thing broke',
+                   this.message);
   });
 
   it('finds metadata', function(){


### PR DESCRIPTION
- It now displays multiline blocks in """ ... """

I'm not sure if the new look is better or not, but the old `prettyjson` had an `engine` requirement section that produces warnings on Node 4.x
